### PR TITLE
Syscall Sysv: Add support for unreferencing callbacks

### DIFF
--- a/func_sysv_test.go
+++ b/func_sysv_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2022 The Ebitengine Authors
+
+//go:build darwin || freebsd || (linux && (amd64 || arm64))
+
+package purego_test
+
+import (
+	"testing"
+
+	"github.com/jwijenbergh/purego"
+)
+
+func TestUnrefCallback(t *testing.T) {
+	imp := func() bool {
+		return true
+	}
+
+	if err := purego.UnrefCallback(0); err == nil {
+		t.Errorf("unref of unknown callback produced nil but wanted error")
+	}
+
+	ref := purego.NewCallback(imp)
+
+	if err := purego.UnrefCallback(ref); err != nil {
+		t.Errorf("callback unref produced %v but wanted nil", err)
+	}
+	if err := purego.UnrefCallback(ref); err == nil {
+		t.Errorf("callback unref of already unref'd callback produced nil but wanted error")
+	}
+}
+
+func TestUnrefCallbackFnPtr(t *testing.T) {
+	imp := func() bool {
+		return true
+	}
+
+	if err := purego.UnrefCallbackFnPtr(&imp); err == nil {
+		t.Errorf("unref of unknown callback produced nil but wanted error")
+	}
+
+	ref := purego.NewCallbackFnPtr(&imp)
+
+	if err := purego.UnrefCallbackFnPtr(&imp); err != nil {
+		t.Errorf("unref produced %v but wanted nil", err)
+	}
+	if err := purego.UnrefCallbackFnPtr(&imp); err == nil {
+		t.Errorf("unref of already unref'd callback produced nil but wanted error")
+	}
+	if err := purego.UnrefCallback(ref); err == nil {
+		t.Errorf("unref of already unref'd callback ptr produced nil but wanted error")
+	}
+}

--- a/func_test.go
+++ b/func_test.go
@@ -135,3 +135,16 @@ func TestRegisterLibFunc_Bool(t *testing.T) {
 		t.Errorf("runFalse failed. got %t but wanted %t", got, expected)
 	}
 }
+
+func TestCallbackFnPtrDedup(t *testing.T) {
+	imp := func() uintptr {
+		return 0
+	}
+
+	ref1 := purego.NewCallbackFnPtr(&imp)
+	ref2 := purego.NewCallbackFnPtr(&imp)
+
+	if ref1 != ref2 {
+		t.Errorf("deduplicate expected %d to equal %d", ref1, ref2)
+	}
+}

--- a/syscall_windows.go
+++ b/syscall_windows.go
@@ -4,11 +4,16 @@
 package purego
 
 import (
+	"reflect"
+	"sync"
 	"syscall"
 	_ "unsafe" // only for go:linkname
 
 	"golang.org/x/sys/windows"
 )
+
+// maxCb is the maximum number of callbacks
+const maxCB = 1024
 
 var syscall15XABI0 uintptr
 
@@ -31,7 +36,53 @@ func syscall_syscall15X(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a
 // callbacks can always be created. Although this function is similiar to the darwin version it may act
 // differently.
 func NewCallback(fn interface{}) uintptr {
+	val := reflect.ValueOf(fn)
+	if val.Kind() != reflect.Func {
+		panic("purego: the type must be a function but was not")
+	}
+	if val.IsNil() {
+		panic("purego: function must not be nil")
+	}
 	return syscall.NewCallback(fn)
+}
+
+// NewCallbackFnPtr converts a Go function pointer to a function pointer conforming to the stdcall calling convention.
+// This is useful when interoperating with C code requiring callbacks. The argument is expected to be a
+// function with one uintptr-sized result. The function must not have arguments with size larger than the
+// size of uintptr. Only a limited number of callbacks may be created in a single Go process, and any memory
+// allocated for these callbacks is never released. Between NewCallback and NewCallbackCDecl, at least 1024
+// callbacks can always be created. Although this function is similiar to the darwin version it may act
+// differently.
+//
+// Calling this function multiple times with the same function pointer will return the originally created callback
+// reference, reducing live callback pressure.
+func NewCallbackFnPtr(fnptr interface{}) uintptr {
+	val := reflect.ValueOf(fnptr)
+	if val.IsNil() {
+		panic("purego: function must not be nil")
+	}
+	if val.Kind() != reflect.Ptr || val.Elem().Kind() != reflect.Func {
+		panic("purego: the type must be a function pointer but was not")
+	}
+
+	// Re-use callback to function pointer if available
+	if addr, ok := getCallbackByFnPtr(val); ok {
+		return addr
+	}
+
+	addr := syscall.NewCallback(val.Elem().Interface())
+
+	cbs.lock.Lock()
+	cbs.knownFnPtr[val.Pointer()] = addr
+	cbs.lock.Unlock()
+	return addr
+}
+
+var cbs = struct {
+	lock       sync.RWMutex
+	knownFnPtr map[uintptr]uintptr // maps function pointers to callback addresses
+}{
+	knownFnPtr: make(map[uintptr]uintptr, maxCB),
 }
 
 //go:linkname openLibrary openLibrary
@@ -42,4 +93,11 @@ func openLibrary(name string) (uintptr, error) {
 
 func loadSymbol(handle uintptr, name string) (uintptr, error) {
 	return windows.GetProcAddress(windows.Handle(handle), name)
+}
+
+func getCallbackByFnPtr(val reflect.Value) (uintptr, bool) {
+	cbs.lock.RLock()
+	defer cbs.lock.RUnlock()
+	addr, ok := cbs.knownFnPtr[val.Pointer()]
+	return addr, ok
 }


### PR DESCRIPTION
Also deduplicate callbacks by function pointer.

Function equality in Go is problematic, which is why functions are not comparable in the language spec or via reflect.Value.Equal().

For our particular use-case though I believe that comparing function pointers is good enough, since we don't need to differentiate closures based on scope variable content.